### PR TITLE
Add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bolt-cli"
 version = "0.1.0"
 edition = "2018"
+repository = "https://github.com/ndaba1/bolt"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
This just makes it easier to find the repo from `crates.io` :)